### PR TITLE
fix: #8 label links

### DIFF
--- a/Issue Tracker/IssueTracker/Issue/view.js
+++ b/Issue Tracker/IssueTracker/Issue/view.js
@@ -54,7 +54,7 @@ function getIssueTrackerFile() {
     return getFile(cur.issueTracker.path)
   }
   // fallback to hardcoded "../Issue Tracker.md"
-  const path = dv.current().file.folder;
+  const path = cur.file.folder;
   const parent = path.substring(0, path.lastIndexOf('/')+1);
   return getFile(parent + "Issue Tracker.md");
 }

--- a/Issue Tracker/IssueTracker/Issue/view.js
+++ b/Issue Tracker/IssueTracker/Issue/view.js
@@ -43,6 +43,22 @@ function getFile(filePath) {
   return file;
 }
 
+
+/**
+ * Returns the TFile of the parent issue tracker if one can be found
+ * @returns {TFile}
+ */
+function getIssueTrackerFile() {
+  const cur = dv.current();
+  if (cur.issueTracker) { // try frontmatter link
+    return getFile(cur.issueTracker.path)
+  }
+  // fallback to hardcoded "../Issue Tracker.md"
+  const path = dv.current().file.folder;
+  const parent = path.substring(0, path.lastIndexOf('/')+1);
+  return getFile(parent + "Issue Tracker.md");
+}
+
 class LabelChip {
   constructor(containerEl, labelText) {
     this.el = containerEl.createSpan({ cls: "label-chip" });
@@ -51,9 +67,7 @@ class LabelChip {
     // Add onclick listener to go back to issueTracker and filter by label
     this.el.onclick = () => {
       // if the location is used as explained in the examples this should work
-      var issueTrackerPath =
-        app.workspace.getActiveFile().parent.parent.path + "/Issue Tracker.md";
-      var issueTrackerFile = getFile(issueTrackerPath);
+      var issueTrackerFile = getIssueTrackerFile();
       // Add frontmatter properties to keep track of the searched label and date when searched
       app.fileManager.processFrontMatter(issueTrackerFile, (frontmatter) => {
         frontmatter["search"] = labelText;

--- a/Issue Tracker/example/Example Project/issues/Example issue.md
+++ b/Issue Tracker/example/Example Project/issues/Example issue.md
@@ -1,4 +1,5 @@
 ---
+issueTracker: "[[Issues - Example Project|Issues]]"
 issueNo: 1
 status: open
 labels:
@@ -9,7 +10,7 @@ labels:
   - milestone
 ---
 
-###### [[Example Project|Example Project]] / [[Issues - Example Project|Issues]]
+###### [[Example Project|Example Project]] / `= this.issueTracker`
 # Example issue
 ```dataviewjs
 dv.view("Issue Tracker/IssueTracker/Issue", { obsidian: obsidian });

--- a/Issue Tracker/templates/note.issue-tracker.issue.md
+++ b/Issue Tracker/templates/note.issue-tracker.issue.md
@@ -22,12 +22,13 @@ if (!window.newIssueInfo) {
 let issueInfo = window.newIssueInfo;
 -%>
 ---
+issueTracker: "<% issueInfo.issueTrackerLink %>"
 issueNo: <% issueInfo.issueNo %>
 status: open
 labels:<% issueInfo.labelsYAML %>
 ---
 
-###### <% issueInfo.projectNoteLink %> / <% issueInfo.issueTrackerLink %>
+###### <% issueInfo.projectNoteLink %> / `= this.issueTracker`
 # <% issueInfo.title %>
 ```dataviewjs
 dv.view("Issue Tracker/IssueTracker/Issue", { obsidian: obsidian });


### PR DESCRIPTION
Adjusted issue template to move issue tracker link into frontmatter; original location replaced with a local dataview query. Changed view to use the frontmatter link or fallback to hardcoded path when clicking label chips. Also behaves well when embedded. Changed example to reflect this.