### PR TITLE
Removed problematic space in json regex

### DIFF
--- a/Obsidian Web Clipper Template/ChatGPT/clipper-chatgpt.json
+++ b/Obsidian Web Clipper Template/ChatGPT/clipper-chatgpt.json
@@ -2,7 +2,7 @@
   "schemaVersion": "0.1.0",
   "name": "ChatGPT",
   "behavior": "create",
-  "noteContentFormat": "{{selectorHtml:article[data-testid*=\"conversation-turn\"]|replace:\"/<svg.*?svg>/g\":\"\"|join:\"\"|remove_html:(\".text-token-text-secondary,.text-token-text-tertiary\")|markdown|replace:(\"/\\s*###### ChatGPT said\\:\\s*/g\":\"\\n\\n[!ChatGPT-response]\\n\", \"/##### You said\\:\\s*/g\": \"[!ChatGPT-prompt]\\n\", \"/^(#{1,6} .*?) \\*\\*(.*)\\*\\*$/gm\":\"$1 $2\")|blockquote|replace:\"\\n> \\n> [!ChatGPT-\":\"\\n\\n> [!ChatGPT-\"}}",
+  "noteContentFormat": "{{selectorHtml:article[data-testid*=\"conversation-turn\"]|replace:\"/<svg.*?svg>/g\":\"\"|join:\"\"|remove_html:(\".text-token-text-secondary,.text-token-text-tertiary\")|markdown|replace:(\"/\\s*###### ChatGPT said\\:\\s*/g\":\"\\n\\n[!ChatGPT-response]\\n\",\"/##### You said\\:\\s*/g\": \"[!ChatGPT-prompt]\\n\", \"/^(#{1,6} .*?) \\*\\*(.*)\\*\\*$/gm\":\"$1 $2\")|blockquote|replace:\"\\n> \\n> [!ChatGPT-\":\"\\n\\n> [!ChatGPT-\"}}",
   "properties": [
     {
       "name": "created",


### PR DESCRIPTION
It looks like an additional space got into the code which broke the ''##### You said" formatting in the web clipper. 

I've removed the space. ¯\_(ツ)_/¯